### PR TITLE
Feat: Add failsafe feature in execution of stages

### DIFF
--- a/doc/source/pipeline.rst
+++ b/doc/source/pipeline.rst
@@ -39,10 +39,16 @@ Example Jenkinsfile
         // harness.set_required_hardware(["zynq-adrv9361-z7035-fmc"])
 
         // Set stages (stages are run sequentially on agents)
+        // Execution type is provided to the second parameter of the 'add_stage' method:
+        //   "stopWhenFail"(Default) -> stops whole pipeline execution at error
+        //                           -> set build status to 'FAILURE'
+        //   "continueWhenFail"      -> stops current stage execution at error but proceeds to next.
+        //                           -> set build status to 'UNSTABLE'
         harness.add_stage(harness.stage_library("UpdateBOOTFiles"))
-        harness.add_stage(harness.stage_library("LinuxTests"))
-        harness.add_stage(harness.stage_library("PyADITests"))
-        harness.add_stage(harness.stage_library("CollectLogs"))
+        harness.add_stage(harness.stage_library("LinuxTests"),"stopWhenFail")
+        harness.add_stage(harness.stage_library("PyADITests"),"continueWhenFail")
+        harness.add_stage(harness.stage_library('LibAD9361Tests'),"continueWhenFail")
+        harness.add_stage(harness.stage_library("CollectLogs"),"continueWhenFail")
         //Above is equivalent to harness.set_default_stages()
 
 

--- a/src/sdg/FailSafeWrapper.groovy
+++ b/src/sdg/FailSafeWrapper.groovy
@@ -1,0 +1,34 @@
+/**
+ * Decorator class to wrap stage closures to ensure graceful failure
+ * if stage is a requisite (i.e build status is FAILURE), 
+ * use 'true' in second param
+ *      ex. def newCls = new FailSafe(oldCls, true)
+ * if stage is not a requisite (i.e build status is UNSTABLEs), 
+ * use 'false' in second param
+ *      ex. def newCls = new FailSafe(oldCls, false)
+ */
+package sdg
+import sdg.NominalException
+
+class FailSafeWrapper {
+    private delegate
+    private isRequisite
+    FailSafeWrapper (delegate,boolean isRequisite=true) {
+        this.delegate = delegate
+        this.isRequisite = isRequisite
+    }
+    def invokeMethod(String name, args) {
+
+        if (isRequisite == true){
+            return delegate.invokeMethod(name, args)
+        }else{
+            try{
+                return delegate.invokeMethod(name, args)
+            }catch(NominalException ex){
+                unstable("Stage is unstable. Reason: $ex")  
+            }catch (Exception ex){
+                error("Stage failed. Error: $ex")
+            }
+        }
+    }
+}

--- a/src/sdg/Gauntlet.groovy
+++ b/src/sdg/Gauntlet.groovy
@@ -1,5 +1,6 @@
 package sdg
-
+import sdg.FailSafeWrapper
+import sdg.NominalException
 /** A map that holds all constants and data members that can be override when constructing  */
 gauntEnv
 
@@ -157,8 +158,10 @@ def stage_library(String stage_name) {
                         board = board.replaceAll('-', '_')
                         cmd = "python3 -m pytest --junitxml=testxml/" + board + "_reports.xml --adi-hw-map -v -k 'not stress' -s --uri='ip:"+ip+"' -m " + board
                         def statusCode = sh script:cmd, returnStatus:true
-                        if ((statusCode != 5) && (statusCode != 0)) // Ignore error 5 which means no tests were run
-                            error "Error code: "+statusCode.toString()
+                        if ((statusCode != 5) && (statusCode != 0)){
+                            // Ignore error 5 which means no tests were run
+                            throw new NominalException('PyADITests Failed')
+                        }                
             }
                 }
                 }
@@ -200,6 +203,7 @@ def stage_library(String stage_name) {
                     println("LibAD9361Tests: Skipping board: "+board)
                 }
             }
+            break
     default:
         throw new Exception('Unknown library stage: ' + stage_name)
     }
@@ -211,8 +215,23 @@ def stage_library(String stage_name) {
  * Add stage to agent pipeline
  * @param cls Closure of stage(s). Should contain at least one stage closure.
  */
-def add_stage(cls) {
-    gauntEnv.stages.add(cls)
+def add_stage(cls, String option='stopWhenFail') {
+    def newCls;
+    switch (option){
+        case 'stopWhenFail':
+            newCls = new FailSafeWrapper(cls, true)
+            break
+        case 'continueWhenFail': 
+            newCls = new FailSafeWrapper(cls, false)
+            break
+        case 'retryWhenFail':
+            // TODO
+            break
+        default:
+            throw new Exception('Unknown stage execution type: ' + option)
+    }
+    
+    gauntEnv.stages.add(newCls)
 }
 
 private def collect_logs() {
@@ -409,9 +428,13 @@ private def check_required_hardware() {
  * will generated and mapped to relevant agents
  */
 def run_stages() {
-    setup_agents()
-    check_required_hardware()
-    run_agents()
+    // make sure log collection stage is called for the whole build
+    // regardless of status i.e SUCCESS, UNSTABLE, FAILURE
+    catchError {
+        setup_agents()
+        check_required_hardware()
+        run_agents()
+    }
     collect_logs()
 }
 

--- a/src/sdg/NominalException.groovy
+++ b/src/sdg/NominalException.groovy
@@ -1,0 +1,10 @@
+/**
+ * Custom exception for non-fatal errors
+ */
+package sdg
+
+class NominalException extends Exception { 
+    NominalException(String errorMessage) {
+        super(errorMessage);
+    }
+}


### PR DESCRIPTION
This feature will allow a custom execution type of a stage when added using the 'Gauntlet.add_stage' method.
This ensures a non-requisite stage to fail gracefully and proceed to next stage.

For this, 2 currently supported options to the 'add_stage' method is added as parameters.

1. "stopWhenFail"(Default) 
- stops whole pipeline execution at error
- set build status to 'FAILURE'
2. "continueWhenFail" 
- stops current stage execution at error but proceeds to next.
- set build status to 'UNSTABLE'

Sample Usage:

```
        harness.add_stage(harness.stage_library("UpdateBOOTFiles")) //Default
        harness.add_stage(harness.stage_library("LinuxTests"),"stopWhenFail")
        harness.add_stage(harness.stage_library("PyADITests"),"continueWhenFail")
        harness.add_stage(harness.stage_library('LibAD9361Tests'),"continueWhenFail")
        harness.add_stage(harness.stage_library("CollectLogs"),"continueWhenFail")
```
