### PR TITLE
Feat: Gauntlet: Add failsafe feature in execution of stages

### DIFF
--- a/doc/source/pipeline.rst
+++ b/doc/source/pipeline.rst
@@ -39,10 +39,16 @@ Example Jenkinsfile
         // harness.set_required_hardware(["zynq-adrv9361-z7035-fmc"])
 
         // Set stages (stages are run sequentially on agents)
+        // Execution type is provided to the second parameter of the 'add_stage' method:
+        //   "stopWhenFail"(Default) -> stops whole pipeline execution at error
+        //                           -> set build status to 'FAILURE'
+        //   "continueWhenFail"      -> stops current stage execution at error but proceeds to next.
+        //                           -> set build status to 'UNSTABLE'
         harness.add_stage(harness.stage_library("UpdateBOOTFiles"))
-        harness.add_stage(harness.stage_library("LinuxTests"))
-        harness.add_stage(harness.stage_library("PyADITests"))
-        harness.add_stage(harness.stage_library("CollectLogs"))
+        harness.add_stage(harness.stage_library("LinuxTests"),"stopWhenFail")
+        harness.add_stage(harness.stage_library("PyADITests"),"continueWhenFail")
+        harness.add_stage(harness.stage_library('LibAD9361Tests'),"continueWhenFail")
+        harness.add_stage(harness.stage_library("CollectLogs"),"continueWhenFail")
         //Above is equivalent to harness.set_default_stages()
 
 

--- a/src/sdg/FailSafeWrapper.groovy
+++ b/src/sdg/FailSafeWrapper.groovy
@@ -1,0 +1,34 @@
+/**
+ * Decorator class to wrap stage closures to ensure graceful failure
+ * if stage is a requisite (i.e build status is FAILURE), 
+ * use 'true' in second param
+ *      ex. def newCls = new FailSafe(oldCls, true)
+ * if stage is not a requisite (i.e build status is UNSTABLEs), 
+ * use 'false' in second param
+ *      ex. def newCls = new FailSafe(oldCls, false)
+ */
+package sdg
+import sdg.NominalException
+
+class FailSafeWrapper {
+    private delegate
+    private isRequisite
+    FailSafeWrapper (delegate,boolean isRequisite=true) {
+        this.delegate = delegate
+        this.isRequisite = isRequisite
+    }
+    def invokeMethod(String name, args) {
+
+        if (isRequisite == true){
+            return delegate.invokeMethod(name, args)
+        }else{
+            try{
+                return delegate.invokeMethod(name, args)
+            }catch(NominalException ex){
+                unstable("Stage is unstable. Reason: $ex")  
+            }catch (Exception ex){
+                error("Stage failed. Error: $ex")
+            }
+        }
+    }
+}

--- a/src/sdg/NominalException.groovy
+++ b/src/sdg/NominalException.groovy
@@ -1,0 +1,10 @@
+/**
+ * Custom exception for non-fatal errors
+ */
+package sdg
+
+class NominalException extends Exception { 
+    NominalException(String errorMessage) {
+        super(errorMessage);
+    }
+}


### PR DESCRIPTION
This feature will allow a custom execution type of a stage when added using the 'Gauntlet.add_stage' method.
This ensures a non-requisite stage to fail gracefully and proceed to next stage.

For this, 2 currently supported options to the 'add_stage' method is added as parameters.

1. "stopWhenFail"(Default) 
- stops whole pipeline execution at error
- set build status to 'FAILURE'
2. "continueWhenFail" 
- stops current stage execution at error but proceeds to next.
- set build status to 'UNSTABLE'

Sample Usage:

```
        harness.add_stage(harness.stage_library("UpdateBOOTFiles")) //Default
        harness.add_stage(harness.stage_library("LinuxTests"),"stopWhenFail")
        harness.add_stage(harness.stage_library("PyADITests"),"continueWhenFail")
        harness.add_stage(harness.stage_library('LibAD9361Tests'),"continueWhenFail")
        harness.add_stage(harness.stage_library("CollectLogs"),"continueWhenFail")
```
