### PR TITLE
Gauntlet: ignore lines with non alphanumeric characters in method 'nebula'

### DIFF
--- a/src/sdg/Gauntlet.groovy
+++ b/src/sdg/Gauntlet.groovy
@@ -561,6 +561,9 @@ def nebula(cmd, full=false, show_log=false) {
             if (lines[i].contains('WARNING')) {
                 continue
             }
+            if (!lines[i].matches(/.*[A-Za-z0-9]+.*/)) {
+                continue
+            }
             if (added > 0) {
                 out = out + '\n'
             }


### PR DESCRIPTION
This modification will ignore lines with non-alphanumeric characters in parsing of 'nebula' method output.

Ex. use case (ignores the following icon which is currently returned by nebula command)


```
    _   __     __          __               ____   ___
   / | / /__  / /_  __  __/ /___ _   _   __/ __ \ <  /
  /  |/ / _ \/ __ \/ / / / / __ `/  | | / / / / / / / 
 / /|  /  __/ /_/ / /_/ / / /_/ /   | |/ / /_/ / / /  
/_/ |_/\___/_.___/\__,_/_/\__,_/    |___/\____(_)_/ 

```


