### PR TITLE
Make docker host mode configureable

### DIFF
--- a/src/sdg/Gauntlet.groovy
+++ b/src/sdg/Gauntlet.groovy
@@ -500,6 +500,14 @@ def set_enable_docker(enable_docker) {
 }
 
 /**
+ * Enable use of docker host mode.
+ * @param docker_host_mode boolean True will enable use of docker host mode
+ */
+def set_docker_host_mode(docker_host_mode) {
+    gauntEnv.docker_host_mode = docker_host_mode
+}
+
+/**
  * Enable update boot to be run before docker is launched.
  * @param set_enable_update_boot_pre_docker boolean True will run update boot stage before docker is launch
  */

--- a/src/sdg/Gauntlet.groovy
+++ b/src/sdg/Gauntlet.groovy
@@ -34,6 +34,7 @@ def construct(List dependencies, hdlBranch, linuxBranch, bootPartitionBranch, fi
             enable_docker: false,
             docker_image: 'tfcollins/sw-ci:latest',
             docker_args: ['MATLAB','Vivado'],
+            docker_host_mode: true,
             enable_update_boot_pre_docker: false,
             setup_called: false,
             nebula_debug: false,
@@ -361,7 +362,9 @@ private def run_agents() {
     docker_args.add('-v /etc/default:/default:ro')
     docker_args.add('-v /dev:/dev')
     docker_args.add('-v /usr/app:/app')
-    docker_args.add('--network host')
+    if (gauntEnv.docker_host_mode) {
+        docker_args.add('--network host')
+    }
     if (docker_args instanceof List) {
         docker_args = docker_args.join(' ')
     }


### PR DESCRIPTION
If docker is in host mode it will break forced mac addresses which are required for MATLAB and Vivado configs.

PR makes it configurable but does not change default behavior.

Please squash merge.